### PR TITLE
Added !admin

### DIFF
--- a/google-cse.php
+++ b/google-cse.php
@@ -103,7 +103,7 @@ function gcse_request($test = false)
  *
  */
 function gcse_results($posts, $q) {
-    if($q->is_single != 1 && $q->is_search == 1) {
+    if($q->is_single != 1 && $q->is_search == 1 && $q->is_admin != 1) {
         global $wp_query;
         $response = gcse_request();
         if(isset($response['items']) && $response['items']) {


### PR DESCRIPTION
I found out this plugin was interfering with Carrington Build by hooking into their AJAX search function. Adding the following line kills this custom search call for admin pages. 
