### PR TITLE
handling Daily limit exceeded by emailing general -> settings -> email

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# WordPress Google CSE
+# WordPress Google CSE Fork to add Daily Limit Exceeded Error issue
 
 This is not another iframe embed or AJAX result listing plugin. Instead search results from your Google Custom Search Engine is served via WordPress search listing. No need to customize your theme or search box.
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,13 @@
 # WordPress Google CSE Fork to handle Daily Limit Exceeded Error issue
 
+The original project does not handle the Daily Limit Exceeded Error.  Using the gcse json api it is possible to exceed the daily limit of search queries which is 100 by default.  You can read more about that here:
+
+https://developers.google.com/custom-search/json-api/v1/overview
+
+The actual json that is returned when the daily limit of search queries are exceeded can be found here:
+
+https://dazdaztech.wordpress.com/2013/08/03/using-google-custom-search-api-from-the-command-line/
+
 This is not another iframe embed or AJAX result listing plugin. Instead search results from your Google Custom Search Engine is served via WordPress search listing. No need to customize your theme or search box.
 
 __You'll need to get an [Google API key](https://code.google.com/apis/console/) and a [Google Custom Search Engine ID](https://www.google.com/cse/) for it to work.__

--- a/README.md
+++ b/README.md
@@ -8,6 +8,13 @@ The actual json that is returned when the daily limit of search queries are exce
 
 https://dazdaztech.wordpress.com/2013/08/03/using-google-custom-search-api-from-the-command-line/
 
+An example email that is produced is:
+
+GCSE JSON API Daily Limit Exceeded on 04/01/2015 01:14:16 AM
+Google Developer Application Key: 1234
+Google Search Engine ID: 1234
+Site URL: http://www.nyb.net
+
 This is not another iframe embed or AJAX result listing plugin. Instead search results from your Google Custom Search Engine is served via WordPress search listing. No need to customize your theme or search box.
 
 __You'll need to get an [Google API key](https://code.google.com/apis/console/) and a [Google Custom Search Engine ID](https://www.google.com/cse/) for it to work.__

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# WordPress Google CSE Fork to add Daily Limit Exceeded Error issue
+# WordPress Google CSE Fork to handle Daily Limit Exceeded Error issue
 
 This is not another iframe embed or AJAX result listing plugin. Instead search results from your Google Custom Search Engine is served via WordPress search listing. No need to customize your theme or search box.
 


### PR DESCRIPTION
I have added some functionality to your excellent plugin to email when the gcse json api exceeds the daily limit.  Please add this to your plugin.
